### PR TITLE
Add version to package meta data.

### DIFF
--- a/xeft.el
+++ b/xeft.el
@@ -1,6 +1,7 @@
 ;;; xeft.el --- Deft feat. Xapian      -*- lexical-binding: t; -*-
 
 ;; Author: Yuan Fu <casouri@gmail.com>
+;; Version: 1.0
 
 ;;; This file is NOT part of GNU Emacs
 


### PR DESCRIPTION
Since emacs 29 add function `package-vc-install` but it require version.