### PR TITLE
Instructions for Apple Silicon devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ You can also build by command line:
 make PREFIX=/opt/local
 ```
 
-Here `/opt/local` is the default prefix of macports, which is what I
-used to install Xapian. Homebrew and Linux users probably can leave it
-empty.
+Here `/opt/local` is the default prefix of macports, which is what
+I used to install Xapian. If you use Homebrew on an Apple Silicon
+device, the prefix must be set to `/opt/homebrew` instead. Other
+Mac users as well as Linux users can probably can leave it empty.
 
 I can’t test it but on windows you can get msys2 and
 `mingw-w64-x86_64-xapian-core` and `make` should just work. Thanks to


### PR DESCRIPTION
Hi! I found out that on an M1 MacBook, the Xapian headers are linked to `/opt/homebrew/include/xapian.h` if you use HomeBrew, so leaving the `PREFIX` empty results in a compilation error.

I added a brief suggestion of this to the `README`.