### PR TITLE
Add GitHub CI for Windows

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,36 @@
+name: MSYS2
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  msys2:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+          - { sys: ucrt64,  env: ucrt-x86_64 }
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        id: msys2
+        with:
+          msystem: ${{matrix.sys}}
+          install: mingw-w64-${{matrix.env}}-openssl mingw-w64-${{matrix.env}}-xapian-core git curl base-devel mingw-w64-${{matrix.env}}-toolchain
+      - name: CI-Build
+        id: build
+        run: |
+          echo 'Running in MSYS2!'
+          cd /home/runneradmin/
+          git clone https://github.com/casouri/xeft
+          cd xeft
+          make
+          cp /${{matrix.sys}}/bin/libxapian-30.dll ./
+      - name: "Upload DLLs"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.env}}-xeft
+          path: ${{ steps.msys2.outputs.msys2-location }}/home/runneradmin/xeft/*.dll


### PR DESCRIPTION
This script uses GitHub Actions to create an Msys2 container and generates compressed packages for `mingw64` ,  `mingw32` ,  and `ucrt64` , each containing `libxapian-30.dll` and `xapian-lite.dll` . I tested the `ucrt` output files, and it works correctly.

该脚本通过GitHub Action创建Msys2容器，并为`mingw64`、`mingw32`、`ucrt64`分别生成了包含`libxapian-30.dll`和`xapian-lite.dll`的压缩包。我测试了其中`ucrt`的版本，可以正常运行。